### PR TITLE
Set folder variable so '+' expansion works

### DIFF
--- a/config/generate-imap.sh
+++ b/config/generate-imap.sh
@@ -10,9 +10,13 @@ echo $SEP >> $FILE
 
 cat variable/01-002-realname.txt >> $FILE
 cat variable/01-003-from.txt >> $FILE
+cat variable/02-002-folder.txt >> $FILE
+
+echo "# set folder=\"imaps://domain.tld/\"" >> $FILE
+
 cat variable/02-003-spoolfile.txt >> $FILE
 
-echo "# set spoolfile=\"imaps://domain.tld/\"" >> $FILE
+echo "# set spoolfile=\"+INBOX\"" >> $FILE
 
 cat variable/02-007-mailboxes.txt >> $FILE
 

--- a/config/neomuttrc-imap-example
+++ b/config/neomuttrc-imap-example
@@ -24,6 +24,19 @@
 
 # set from="mailbox@domain.tld"
 # -------------------------------------------------------------------------
+# Name: folder
+# -------------------------------------------------------------------------
+# Specifies the default location of your mailboxes.  A “+” or “=” at the
+# beginning  of  a pathname  will be expanded to the value of this
+# variable.  Note that if you change this variable (from the default) value
+# you need to make  sure  that  the  assignment  occurs before you use “+”
+# or “=” for any other variables since expansion takes place when han‐
+# dling the “mailboxes” command.
+# -------------------------------------------------------------------------
+
+# set folder=~/Mail
+# set folder="imaps://domain.tld/"
+# -------------------------------------------------------------------------
 # Name: spoolfile
 # -------------------------------------------------------------------------
 # If your spool mailbox is in a non-default place where NeoMutt cannot find
@@ -32,7 +45,7 @@
 # -------------------------------------------------------------------------
 
 # set spoolfile = ""
-# set spoolfile="imaps://domain.tld/"
+# set spoolfile="+INBOX"
 # -------------------------------------------------------------------------
 # Name: mailboxes
 # -------------------------------------------------------------------------


### PR DESCRIPTION
The `mailboxes +Drafts +Sent +Spam` example will not work because the `folder` variable is not set to the proper path, i.e., the IMAP server. By default, the `folder` variable is set to `~/Mail` and therefore `+` as used in the example will expand to `~/Mail` rather than to the IMAP server.

This PR correctly sets the `folder` variable to the IMAP server. And since `+` now expands correctly, `$spoolfile` can be and in this PR is set to `+INBOX`.